### PR TITLE
feat: trailing comma aware formatting

### DIFF
--- a/results/comment_test.dart
+++ b/results/comment_test.dart
@@ -1,0 +1,30 @@
+// Comment test cases — commented out code must never be touched by the formatter
+
+// Case 1: single-line comment containing a trailing comma call — must not expand
+// myFunction(arg1, arg2,)
+
+// Case 2: doc comment containing a trailing comma call — must not expand
+/// myFunction(arg1, arg2,)
+
+// Case 3: inline block comment on one line — must not expand
+/* myFunction(arg1, arg2,) */
+
+// Case 4: multi-line block comment containing a trailing comma call — must not expand
+/*
+Widget build(BuildContext context) {
+  return Scaffold(
+    appBar: appBar,
+    body: body,
+    backgroundColor: style.backgroundColor,
+  );
+}
+*/
+
+// Case 5: real code after comments — trailing comma must still expand normally
+void realCode()
+{
+	myFunction(
+		arg1,
+		arg2,
+	);
+}

--- a/results/trailing_comma_test.dart
+++ b/results/trailing_comma_test.dart
@@ -1,0 +1,113 @@
+// Trailing comma formatting test cases
+
+// Case 1: trailing comma present — must expand to multi-line
+void caseTrailingCommaExpand()
+{
+	myFunction(
+		arg1,
+		arg2,
+		arg3,
+	);
+}
+
+// Case 2: no trailing comma, fits on one line — must collapse to single line
+void caseNoTrailingCommaCollapse()
+{
+	myFunction(arg1, arg2, arg3);
+}
+
+// Case 3: no trailing comma, does NOT fit on one line — must expand without adding comma
+void caseNoTrailingCommaTooLong()
+{
+	myFunction(
+		veryLongArgumentNameOne,
+		veryLongArgumentNameTwo,
+		veryLongArgumentNameThree
+	);
+}
+
+// Case 4: already correctly formatted multi-line with trailing comma — no change
+void caseAlreadyMultiLine()
+{
+	myFunction(
+		arg1,
+		arg2,
+		arg3,
+	);
+}
+
+// Case 5: already correctly formatted single-line — no change
+void caseAlreadySingleLine()
+{
+	myFunction(arg1, arg2, arg3);
+}
+
+// Case 6: empty list — always single line, no change
+void caseEmptyList()
+{
+	myFunction();
+}
+
+// Case 7: single argument with trailing comma — must expand
+void caseSingleArgWithTrailingComma()
+{
+	myFunction(
+		singleArg,
+	);
+}
+
+// Case 8: named parameters with trailing comma
+void caseNamedParams()
+{
+	myFunction(
+		positional,
+		named: value,
+	);
+}
+
+// Case 9: list literal with trailing comma
+void caseListLiteral()
+{
+	var list = [
+		item1,
+		item2,
+		item3,
+	];
+}
+
+// Case 10: list literal without trailing comma, fits — collapse
+void caseListNoTrailingComma()
+{
+	var list = [item1, item2];
+}
+
+// Case 11: nested structures, both with trailing commas
+void caseNested()
+{
+	OuterWidget(
+		child: InnerWidget(
+			param1,
+			param2,
+		),
+		color: Colors.red,
+	);
+}
+
+// Case 12: inline comment forces multi-line even without trailing comma
+void caseInlineComment()
+{
+	myFunction(
+		arg1,
+		// important
+		arg2
+	);
+}
+
+// Case 13: constructor call with trailing comma
+void caseConstructor()
+{
+	return MyClass(
+		field1: "hello",
+		field2: 42,
+	);
+}

--- a/samples/comment_test.dart
+++ b/samples/comment_test.dart
@@ -1,0 +1,26 @@
+// Comment test cases — commented out code must never be touched by the formatter
+
+// Case 1: single-line comment containing a trailing comma call — must not expand
+// myFunction(arg1, arg2,)
+
+// Case 2: doc comment containing a trailing comma call — must not expand
+/// myFunction(arg1, arg2,)
+
+// Case 3: inline block comment on one line — must not expand
+/* myFunction(arg1, arg2,) */
+
+// Case 4: multi-line block comment containing a trailing comma call — must not expand
+/*
+Widget build(BuildContext context) {
+  return Scaffold(
+    appBar: appBar,
+    body: body,
+    backgroundColor: style.backgroundColor,
+  );
+}
+*/
+
+// Case 5: real code after comments — trailing comma must still expand normally
+void realCode() {
+  myFunction(arg1, arg2,);
+}

--- a/samples/trailing_comma_test.dart
+++ b/samples/trailing_comma_test.dart
@@ -1,0 +1,80 @@
+// Trailing comma formatting test cases
+
+// Case 1: trailing comma present — must expand to multi-line
+void caseTrailingCommaExpand() {
+  myFunction(arg1, arg2, arg3,);
+}
+
+// Case 2: no trailing comma, fits on one line — must collapse to single line
+void caseNoTrailingCommaCollapse() {
+  myFunction(
+    arg1,
+    arg2,
+    arg3
+  );
+}
+
+// Case 3: no trailing comma, does NOT fit on one line — must expand without adding comma
+void caseNoTrailingCommaTooLong() {
+  myFunction(veryLongArgumentNameOne, veryLongArgumentNameTwo, veryLongArgumentNameThree);
+}
+
+// Case 4: already correctly formatted multi-line with trailing comma — no change
+void caseAlreadyMultiLine() {
+  myFunction(
+    arg1,
+    arg2,
+    arg3,
+  );
+}
+
+// Case 5: already correctly formatted single-line — no change
+void caseAlreadySingleLine() {
+  myFunction(arg1, arg2, arg3);
+}
+
+// Case 6: empty list — always single line, no change
+void caseEmptyList() {
+  myFunction();
+}
+
+// Case 7: single argument with trailing comma — must expand
+void caseSingleArgWithTrailingComma() {
+  myFunction(singleArg,);
+}
+
+// Case 8: named parameters with trailing comma
+void caseNamedParams() {
+  myFunction(positional, named: value,);
+}
+
+// Case 9: list literal with trailing comma
+void caseListLiteral() {
+  var list = [item1, item2, item3,];
+}
+
+// Case 10: list literal without trailing comma, fits — collapse
+void caseListNoTrailingComma() {
+  var list = [
+    item1,
+    item2
+  ];
+}
+
+// Case 11: nested structures, both with trailing commas
+void caseNested() {
+  OuterWidget(child: InnerWidget(param1, param2,), color: Colors.red,);
+}
+
+// Case 12: inline comment forces multi-line even without trailing comma
+void caseInlineComment() {
+  myFunction(
+    arg1, // important
+    arg2
+  );
+}
+
+// Case 13: constructor call with trailing comma
+void caseConstructor() {
+  return MyClass(field1: "hello", field2: 42,);
+}

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,4 +1,5 @@
 use crate::config::{self, IndentationStyle};
+use crate::trailing_comma;
 use regex::Regex;
 use std::collections::HashMap;
 use substring::Substring;
@@ -16,6 +17,7 @@ pub(crate) struct FormatterResult
 	pub(crate) incorrect_quotes: i32,
 	pub(crate) incorrect_else_placements: i32,
 	pub(crate) incorrect_break_placements: i32,
+	pub(crate) incorrect_trailing_comma_formats: i32,
 }
 
 struct IncorrectSwitchBreakIndentation
@@ -99,12 +101,17 @@ impl Formatter
 		let cleaned_content3 = self.correct_switch_break_indentations(&cleaned_content2);
 		let cleaned_content4 = self.correct_weird_elses(&cleaned_content3);
 
+		// Trailing comma pass — runs after all existing passes, does not
+		// modify any of the logic above.
+		let cleaned_content5 = trailing_comma::format_trailing_commas(&cleaned_content4);
+		let incorrect_trailing_comma_formats = if cleaned_content5 != cleaned_content4 { 1 } else { 0 };
+
 		// if self.config.use_treesitter_to_format
 		// {
 		// 	return FormatterResult { content: self.format_using_treesitter(cleaned_content4), incorrect_curly_braces, incorrect_indentations, incorrect_quotes, incorrect_else_placements, incorrect_break_placements };
 		// }
 
-		return FormatterResult { content: cleaned_content4, incorrect_curly_braces, incorrect_indentations, incorrect_quotes, incorrect_else_placements, incorrect_break_placements };
+		return FormatterResult { content: cleaned_content5, incorrect_curly_braces, incorrect_indentations, incorrect_quotes, incorrect_else_placements, incorrect_break_placements, incorrect_trailing_comma_formats };
 	}
 
 	fn forbidden_lines(&self, content: &String) -> Vec<i32>

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -177,6 +177,31 @@ impl Formatter
 			line_number += 1;
 		}
 
+		let mut is_inside_block_comment = false;
+		line_number = 0;
+
+		for line in content.lines()
+		{
+			if is_inside_block_comment
+			{
+				forbidden.push(line_number);
+				if line.contains("*/")
+				{
+					is_inside_block_comment = false;
+				}
+			}
+			else if line.trim().contains("/*")
+			{
+				forbidden.push(line_number);
+				let after_open = &line[line.find("/*").unwrap() + 2..];
+				if !after_open.contains("*/")
+				{
+					is_inside_block_comment = true;
+				}
+			}
+			line_number += 1;
+		}
+
 		return forbidden;
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use ignores::load_ignores;
 mod config;
 mod formatter;
 mod ignores;
+mod trailing_comma;
 // mod treesitter;
 
 fn main()
@@ -212,7 +213,7 @@ fn format_file_in_folder(config: config::Config, path: &PathBuf, ignores: &HashS
 				println!("{}", result.content);
 
 				println!("Stats for {} (wrongs): ", path.display());
-				println!("  curlies: {} quotes: {} elses: {} indents: {} breaks: {}", result.incorrect_curly_braces, result.incorrect_quotes, result.incorrect_else_placements, result.incorrect_indentations, result.incorrect_break_placements);
+				println!("  curlies: {} quotes: {} elses: {} indents: {} breaks: {} trailing_commas: {}", result.incorrect_curly_braces, result.incorrect_quotes, result.incorrect_else_placements, result.incorrect_indentations, result.incorrect_break_placements, result.incorrect_trailing_comma_formats);
 			}
 			else
 			{

--- a/src/trailing_comma.rs
+++ b/src/trailing_comma.rs
@@ -1,0 +1,586 @@
+// Public entry point. Runs the single_pass loop until the output stabilises
+// (up to 5 iterations). Multiple passes are needed so that nested structures
+// converge to correct indentation: the first pass formats inner spans using
+// the indentation context of the *original* source; subsequent passes
+// re-read the now-correct indentation of each inner span and reformat
+// accordingly.
+pub(crate) fn format_trailing_commas(content: &str) -> String
+{
+	let mut result = content.to_string();
+	for _ in 0..5
+	{
+		let next = single_pass(&result);
+		if next == result
+		{
+			break;
+		}
+		result = next;
+	}
+	result
+}
+
+// ---------------------------------------------------------------------------
+// Span — one matched delimiter pair
+// ---------------------------------------------------------------------------
+
+struct Span
+{
+	open: usize,         // byte index of opening delimiter  ( or [
+	close: usize,        // byte index of closing delimiter  ) or ]
+	indent_level: usize, // number of tabs at the start of the line that contains `open`
+}
+
+// ---------------------------------------------------------------------------
+// single_pass — one full scan + replace cycle
+// ---------------------------------------------------------------------------
+
+fn single_pass(content: &str) -> String
+{
+	let mut spans = find_spans(content);
+	if spans.is_empty()
+	{
+		return content.to_string();
+	}
+
+	// Process right-to-left (highest open index first = innermost/rightmost
+	// first). This preserves byte offsets for outer spans that haven't been
+	// processed yet — except that their `close` index shifts when the inner
+	// replacement changes length, so we update those below.
+	spans.sort_by(|a, b| b.open.cmp(&a.open));
+
+	let mut result = content.to_string();
+
+	for i in 0..spans.len()
+	{
+		let span_open = spans[i].open;
+		let span_close = spans[i].close;
+		let indent = spans[i].indent_level;
+
+		let fragment = result[span_open..=span_close].to_string();
+		let replacement = format_span(&fragment, indent);
+
+		let old_len = span_close - span_open + 1;
+		let new_len = replacement.len();
+
+		result.replace_range(span_open..=span_close, &replacement);
+
+		// Adjust the `close` index of any outer spans (lower open index,
+		// therefore processed later) whose closing delimiter sits after the
+		// region we just replaced.
+		if new_len != old_len
+		{
+			let delta: isize = new_len as isize - old_len as isize;
+			for j in (i + 1)..spans.len()
+			{
+				if spans[j].close > span_close
+				{
+					spans[j].close = (spans[j].close as isize + delta) as usize;
+				}
+			}
+		}
+	}
+
+	result
+}
+
+// ---------------------------------------------------------------------------
+// find_spans — character-level scanner
+// ---------------------------------------------------------------------------
+
+fn find_spans(content: &str) -> Vec<Span>
+{
+	let bytes = content.as_bytes();
+	let n = bytes.len();
+
+	let mut spans: Vec<Span> = Vec::new();
+	// stack entries: (open_byte_pos, open_char, indent_level, should_record)
+	// should_record is always true for ( and [.
+	// For { it is true only when preceded by ( or , — i.e. a named parameter
+	// block or a map/set literal passed as an argument, not a block body.
+	let mut stack: Vec<(usize, char, usize, bool)> = Vec::new();
+
+	// Tracks the last non-whitespace byte seen in Normal mode.
+	// Used to decide whether { is a parameter block (preceded by ( or ,)
+	// or a block body (preceded by ) or an identifier/keyword).
+	let mut last_sig: u8 = b' ';
+
+	let mut i = 0usize;
+	let mut line_start = 0usize;
+
+	// Scanner state
+	let mut in_single_string = false;
+	let mut single_quote: u8 = b'"';
+	let mut in_multi_string = false;
+	let mut multi_quote: u8 = b'"';
+	let mut in_line_comment = false;
+
+	while i < n
+	{
+		let c = bytes[i];
+
+		// --- inside a line comment ---
+		if in_line_comment
+		{
+			if c == b'\n'
+			{
+				in_line_comment = false;
+				line_start = i + 1;
+			}
+			i += 1;
+			continue;
+		}
+
+		// --- inside a multi-line string ---
+		if in_multi_string
+		{
+			if c == b'\n'
+			{
+				line_start = i + 1;
+			}
+			else if c == multi_quote && i + 2 < n && bytes[i + 1] == multi_quote && bytes[i + 2] == multi_quote
+			{
+				in_multi_string = false;
+				i += 3;
+				continue;
+			}
+			i += 1;
+			continue;
+		}
+
+		// --- inside a single-line string ---
+		if in_single_string
+		{
+			if c == b'\\' && i + 1 < n
+			{
+				i += 2; // skip escape sequence
+				continue;
+			}
+			if c == single_quote
+			{
+				in_single_string = false;
+			}
+			i += 1;
+			continue;
+		}
+
+		// --- normal mode ---
+
+		if c == b'\n'
+		{
+			line_start = i + 1;
+			i += 1;
+			continue;
+		}
+
+		// Check for multi-line string opening: ''' or """
+		if (c == b'\'' || c == b'"') && i + 2 < n && bytes[i + 1] == c && bytes[i + 2] == c
+		{
+			in_multi_string = true;
+			multi_quote = c;
+			last_sig = c;
+			i += 3;
+			continue;
+		}
+
+		// Check for line comment //
+		if c == b'/' && i + 1 < n && bytes[i + 1] == b'/'
+		{
+			in_line_comment = true;
+			i += 2;
+			continue;
+		}
+
+		// Check for single-line string opening
+		if c == b'\'' || c == b'"'
+		{
+			in_single_string = true;
+			single_quote = c;
+			last_sig = c;
+			i += 1;
+			continue;
+		}
+
+		// Opening ( and [
+		if c == b'(' || c == b'['
+		{
+			let indent = tabs_at_line_start(bytes, line_start);
+			stack.push((i, c as char, indent, true));
+			last_sig = c;
+			i += 1;
+			continue;
+		}
+
+		// Opening { — only record as a span when it is a named parameter block
+		// or a map/set literal passed as an argument, identified by the
+		// preceding non-whitespace character being ( or ,.
+		// Block bodies are always preceded by ) (if-body, for-body, function
+		// body after signature) or by an identifier/keyword (class, else, etc.)
+		// and are therefore not recorded.
+		if c == b'{'
+		{
+			let indent = tabs_at_line_start(bytes, line_start);
+			let should_record = last_sig == b'(' || last_sig == b',';
+			stack.push((i, '{', indent, should_record));
+			last_sig = c;
+			i += 1;
+			continue;
+		}
+
+		// Closing delimiters
+		if c == b')' || c == b']' || c == b'}'
+		{
+			if let Some(&(open_pos, open_char, indent, should_record)) = stack.last()
+			{
+				let matched = (c == b')' && open_char == '(')
+					|| (c == b']' && open_char == '[')
+					|| (c == b'}' && open_char == '{');
+
+				if matched
+				{
+					stack.pop();
+					if should_record
+					{
+						spans.push(Span { open: open_pos, close: i, indent_level: indent });
+					}
+				}
+				// If not matched (malformed source) leave the stack as-is.
+			}
+			last_sig = c;
+			i += 1;
+			continue;
+		}
+
+		// All other Normal-mode characters — update last_sig for non-whitespace
+		if c != b' ' && c != b'\t'
+		{
+			last_sig = c;
+		}
+		i += 1;
+	}
+
+	spans
+}
+
+// ---------------------------------------------------------------------------
+// format_span — decide and render a single delimiter pair
+// ---------------------------------------------------------------------------
+
+fn format_span(fragment: &str, indent_level: usize) -> String
+{
+	if fragment.len() < 2
+	{
+		return fragment.to_string();
+	}
+
+	let open_char = fragment.chars().next().unwrap();
+	let close_char = fragment.chars().last().unwrap();
+	let inner = &fragment[1..fragment.len() - 1];
+
+	let elements = split_elements(inner);
+	let non_empty: Vec<String> = elements.into_iter().map(|e| e.trim().to_string()).filter(|e| !e.is_empty()).collect();
+
+	// Empty list — always single line, no change
+	if non_empty.is_empty()
+	{
+		return format!("{}{}", open_char, close_char);
+	}
+
+	let trailing = has_trailing_comma(inner);
+	let inline_comments = has_inline_comments(inner);
+
+	if trailing || inline_comments
+	{
+		return render_multi_line(open_char, &non_empty, close_char, indent_level, trailing);
+	}
+
+	let single = render_single_line(open_char, &non_empty, close_char);
+
+	// If the single-line form already contains newlines it means one of the
+	// inner elements was expanded to multi-line by an earlier pass (e.g. a
+	// named-parameter block { ... } that was just formatted). In that case,
+	// leave the outer delimiter pair as-is — the natural wrapping produced by
+	// the inner pass is already correct and adding another layer of indentation
+	// would be wrong.
+	if single.contains('\n')
+	{
+		return fragment.to_string();
+	}
+
+	// No trailing comma → always single line, regardless of length.
+	single
+}
+
+// ---------------------------------------------------------------------------
+// split_elements — split inner content by top-level commas
+// ---------------------------------------------------------------------------
+
+fn split_elements(inner: &str) -> Vec<String>
+{
+	let mut elements: Vec<String> = Vec::new();
+	let mut current = String::new();
+	let mut depth = 0usize;
+
+	let mut in_single = false;
+	let mut single_q = '"';
+	let mut in_multi = false;
+	let mut multi_q = '"';
+	let mut in_comment = false;
+
+	let chars: Vec<char> = inner.chars().collect();
+	let n = chars.len();
+	let mut i = 0usize;
+
+	while i < n
+	{
+		let c = chars[i];
+
+		if in_comment
+		{
+			current.push(c);
+			if c == '\n'
+			{
+				in_comment = false;
+			}
+			i += 1;
+			continue;
+		}
+
+		if in_multi
+		{
+			current.push(c);
+			if c == multi_q && i + 2 < n && chars[i + 1] == multi_q && chars[i + 2] == multi_q
+			{
+				current.push(chars[i + 1]);
+				current.push(chars[i + 2]);
+				in_multi = false;
+				i += 3;
+				continue;
+			}
+			i += 1;
+			continue;
+		}
+
+		if in_single
+		{
+			current.push(c);
+			if c == '\\' && i + 1 < n
+			{
+				current.push(chars[i + 1]);
+				i += 2;
+				continue;
+			}
+			if c == single_q
+			{
+				in_single = false;
+			}
+			i += 1;
+			continue;
+		}
+
+		// Check for line comment
+		if c == '/' && i + 1 < n && chars[i + 1] == '/'
+		{
+			in_comment = true;
+			current.push(c);
+			i += 1;
+			continue;
+		}
+
+		// Check for multi-line string
+		if (c == '\'' || c == '"') && i + 2 < n && chars[i + 1] == c && chars[i + 2] == c
+		{
+			in_multi = true;
+			multi_q = c;
+			current.push(c);
+			i += 1;
+			continue;
+		}
+
+		// Check for single-line string
+		if c == '\'' || c == '"'
+		{
+			in_single = true;
+			single_q = c;
+			current.push(c);
+			i += 1;
+			continue;
+		}
+
+		// Track nesting
+		if c == '(' || c == '[' || c == '{'
+		{
+			depth += 1;
+			current.push(c);
+			i += 1;
+			continue;
+		}
+		if c == ')' || c == ']' || c == '}'
+		{
+			if depth > 0
+			{
+				depth -= 1;
+			}
+			current.push(c);
+			i += 1;
+			continue;
+		}
+
+		// Top-level comma = element separator
+		if c == ',' && depth == 0
+		{
+			elements.push(current.clone());
+			current = String::new();
+			i += 1;
+			continue;
+		}
+
+		current.push(c);
+		i += 1;
+	}
+
+	// Push whatever remains after the last comma (may be empty for trailing comma)
+	elements.push(current);
+
+	elements
+}
+
+// ---------------------------------------------------------------------------
+// has_trailing_comma
+// ---------------------------------------------------------------------------
+
+fn has_trailing_comma(inner: &str) -> bool
+{
+	// Walk lines in reverse; on the first non-blank line (after stripping any
+	// inline comment) check whether the last meaningful char is a comma.
+	for line in inner.lines().rev()
+	{
+		let effective = strip_line_comment(line.trim_end()).trim_end();
+		if effective.is_empty()
+		{
+			continue;
+		}
+		return effective.ends_with(',');
+	}
+
+	// inner had no newlines — treat it as a single line
+	let effective = strip_line_comment(inner.trim_end()).trim_end();
+	effective.ends_with(',')
+}
+
+fn strip_line_comment(s: &str) -> &str
+{
+	// Simplified: find the first `//` not inside a string.
+	// For correctness we do a minimal scan rather than just `find("//")`.
+	let chars: Vec<char> = s.chars().collect();
+	let n = chars.len();
+	let mut i = 0usize;
+	let mut in_str = false;
+	let mut str_char = '"';
+	while i < n
+	{
+		let c = chars[i];
+		if in_str
+		{
+			if c == '\\' && i + 1 < n
+			{
+				i += 2;
+				continue;
+			}
+			if c == str_char
+			{
+				in_str = false;
+			}
+		}
+		else
+		{
+			if c == '"' || c == '\''
+			{
+				in_str = true;
+				str_char = c;
+			}
+			else if c == '/' && i + 1 < n && chars[i + 1] == '/'
+			{
+				// Return the slice up to this point
+				let byte_pos = s.char_indices().nth(i).map(|(b, _)| b).unwrap_or(s.len());
+				return &s[..byte_pos];
+			}
+		}
+		i += 1;
+	}
+	s
+}
+
+// ---------------------------------------------------------------------------
+// has_inline_comments
+// ---------------------------------------------------------------------------
+
+fn has_inline_comments(inner: &str) -> bool
+{
+	for line in inner.lines()
+	{
+		let trimmed = line.trim();
+		if trimmed.starts_with("//")
+		{
+			// Full-line comment — does not force multi-line on its own
+			continue;
+		}
+		// Inline comment: there is text before the `//`
+		if strip_line_comment(trimmed).trim_end().len() < trimmed.len()
+		{
+			return true;
+		}
+	}
+	false
+}
+
+// ---------------------------------------------------------------------------
+// Renderers
+// ---------------------------------------------------------------------------
+
+fn render_single_line(open: char, elements: &[String], close: char) -> String
+{
+	let parts: Vec<&str> = elements.iter().map(|e| e.trim()).collect();
+	format!("{}{}{}", open, parts.join(","), close)
+}
+
+fn render_multi_line(open: char, elements: &[String], close: char, indent_level: usize, has_trailing: bool) -> String
+{
+	let indent = "\t".repeat(indent_level);
+	let child_indent = "\t".repeat(indent_level + 1);
+
+	let mut out = format!("{}\n", open);
+
+	for (idx, element) in elements.iter().enumerate()
+	{
+		let is_last = idx == elements.len() - 1;
+		let trimmed = element.trim();
+		if is_last && !has_trailing
+		{
+			out.push_str(&format!("{}{}\n", child_indent, trimmed));
+		}
+		else
+		{
+			out.push_str(&format!("{}{},\n", child_indent, trimmed));
+		}
+	}
+
+	out.push_str(&format!("{}{}", indent, close));
+	out
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tabs_at_line_start(bytes: &[u8], line_start: usize) -> usize
+{
+	let mut count = 0usize;
+	let mut i = line_start;
+	while i < bytes.len() && bytes[i] == b'\t'
+	{
+		count += 1;
+		i += 1;
+	}
+	count
+}
+

--- a/src/trailing_comma.rs
+++ b/src/trailing_comma.rs
@@ -293,6 +293,12 @@ fn format_span(fragment: &str, indent_level: usize) -> String
 		return render_multi_line(open_char, &non_empty, close_char, indent_level, trailing);
 	}
 
+	// No trailing comma and already single-line — leave completely untouched.
+	if !fragment.contains('\n')
+	{
+		return fragment.to_string();
+	}
+
 	let single = render_single_line(open_char, &non_empty, close_char);
 
 	// If the single-line form already contains newlines it means one of the
@@ -306,7 +312,7 @@ fn format_span(fragment: &str, indent_level: usize) -> String
 		return fragment.to_string();
 	}
 
-	// No trailing comma → always single line, regardless of length.
+	// No trailing comma, was multi-line → collapse to single line.
 	single
 }
 
@@ -540,7 +546,7 @@ fn has_inline_comments(inner: &str) -> bool
 fn render_single_line(open: char, elements: &[String], close: char) -> String
 {
 	let parts: Vec<&str> = elements.iter().map(|e| e.trim()).collect();
-	format!("{}{}{}", open, parts.join(","), close)
+	format!("{}{}{}", open, parts.join(", "), close)
 }
 
 fn render_multi_line(open: char, elements: &[String], close: char, indent_level: usize, has_trailing: bool) -> String

--- a/src/trailing_comma.rs
+++ b/src/trailing_comma.rs
@@ -113,6 +113,7 @@ fn find_spans(content: &str) -> Vec<Span>
 	let mut in_multi_string = false;
 	let mut multi_quote: u8 = b'"';
 	let mut in_line_comment = false;
+	let mut in_block_comment = false;
 
 	while i < n
 	{
@@ -125,6 +126,23 @@ fn find_spans(content: &str) -> Vec<Span>
 			{
 				in_line_comment = false;
 				line_start = i + 1;
+			}
+			i += 1;
+			continue;
+		}
+
+		// --- inside a block comment ---
+		if in_block_comment
+		{
+			if c == b'\n'
+			{
+				line_start = i + 1;
+			}
+			else if c == b'*' && i + 1 < n && bytes[i + 1] == b'/'
+			{
+				in_block_comment = false;
+				i += 2;
+				continue;
 			}
 			i += 1;
 			continue;
@@ -179,6 +197,14 @@ fn find_spans(content: &str) -> Vec<Span>
 			multi_quote = c;
 			last_sig = c;
 			i += 3;
+			continue;
+		}
+
+		// Check for block comment /*
+		if c == b'/' && i + 1 < n && bytes[i + 1] == b'*'
+		{
+			in_block_comment = true;
+			i += 2;
 			continue;
 		}
 
@@ -542,7 +568,8 @@ fn render_multi_line(open: char, elements: &[String], close: char, indent_level:
 	{
 		let is_last = idx == elements.len() - 1;
 		let trimmed = element.trim();
-		if is_last && !has_trailing
+		let is_comment = trimmed.starts_with("//");
+		if is_comment || (is_last && !has_trailing)
 		{
 			out.push_str(&format!("{}{}\n", child_indent, trimmed));
 		}
@@ -572,3 +599,81 @@ fn tabs_at_line_start(bytes: &[u8], line_start: usize) -> usize
 	count
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests
+{
+	use super::*;
+
+	// -- // single-line comments --
+
+	#[test]
+	fn line_comment_with_trailing_comma_not_expanded()
+	{
+		// A trailing comma inside a // comment must never trigger expansion.
+		let input = "// myFunction(arg1, arg2,)\n";
+		assert_eq!(format_trailing_commas(input), input);
+	}
+
+	#[test]
+	fn line_comment_mixed_with_real_code()
+	{
+		// The comment line is untouched; the real call below it is expanded.
+		let input = "// ignored(a, b,)\nmyFunction(a, b,);\n";
+		let expected = "// ignored(a, b,)\nmyFunction(\n\ta,\n\tb,\n);\n";
+		assert_eq!(format_trailing_commas(input), expected);
+	}
+
+	// -- /// doc comments --
+
+	#[test]
+	fn doc_comment_with_trailing_comma_not_expanded()
+	{
+		let input = "/// myFunction(arg1, arg2,)\n";
+		assert_eq!(format_trailing_commas(input), input);
+	}
+
+	// -- /* */ block comments --
+
+	#[test]
+	fn block_comment_single_line_not_expanded()
+	{
+		// Inline block comment on one line — must not be touched.
+		let input = "/* myFunction(arg1, arg2,) */\n";
+		assert_eq!(format_trailing_commas(input), input);
+	}
+
+	#[test]
+	fn block_comment_multi_line_not_expanded()
+	{
+		// A multi-line block comment containing a trailing-comma call.
+		let input = "/*\nmyFunction(\n\targ1,\n\targ2,\n)\n*/\n";
+		assert_eq!(format_trailing_commas(input), input);
+	}
+
+	#[test]
+	fn block_comment_mixed_with_real_code()
+	{
+		// Content inside /* */ is untouched; code outside is still formatted.
+		let input = "/* ignored(a, b,) */\nmyFunction(a, b,);\n";
+		let expected = "/* ignored(a, b,) */\nmyFunction(\n\ta,\n\tb,\n);\n";
+		assert_eq!(format_trailing_commas(input), expected);
+	}
+
+	#[test]
+	fn inline_comment_element_does_not_accumulate_commas()
+	{
+		// A commented-out line inside a trailing-comma span must never have
+		// extra commas appended to it across formatter passes.
+		let input = "myFunction(\n\targ1,\n\t// disabled: value,\n\targ2,\n);\n";
+		let result = format_trailing_commas(input);
+		assert!(
+			!result.contains(",,"),
+			"comment line should not accumulate commas, got:\n{}",
+			result
+		);
+	}
+}

--- a/src/trailing_comma.rs
+++ b/src/trailing_comma.rs
@@ -286,34 +286,16 @@ fn format_span(fragment: &str, indent_level: usize) -> String
 	}
 
 	let trailing = has_trailing_comma(inner);
+
+	// Only reformat spans that already have a trailing comma.
+	// If there is no trailing comma, leave the fragment completely untouched.
+	if !trailing
+	{
+		return fragment.to_string();
+	}
+
 	let inline_comments = has_inline_comments(inner);
-
-	if trailing || inline_comments
-	{
-		return render_multi_line(open_char, &non_empty, close_char, indent_level, trailing);
-	}
-
-	// No trailing comma and already single-line — leave completely untouched.
-	if !fragment.contains('\n')
-	{
-		return fragment.to_string();
-	}
-
-	let single = render_single_line(open_char, &non_empty, close_char);
-
-	// If the single-line form already contains newlines it means one of the
-	// inner elements was expanded to multi-line by an earlier pass (e.g. a
-	// named-parameter block { ... } that was just formatted). In that case,
-	// leave the outer delimiter pair as-is — the natural wrapping produced by
-	// the inner pass is already correct and adding another layer of indentation
-	// would be wrong.
-	if single.contains('\n')
-	{
-		return fragment.to_string();
-	}
-
-	// No trailing comma, was multi-line → collapse to single line.
-	single
+	render_multi_line(open_char, &non_empty, close_char, indent_level, trailing || inline_comments)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a trailing comma formatting pass to the Blink formatter.

  ## What it does

  - When a parameter list or argument list contains a trailing comma, the formatter expands it into multi-line format with correct tab indentation, one element per line.
  - Spans without a trailing comma are left completely untouched — no collapsing, no spacing changes, no reformatting of any kind.
  - The pass runs after all existing formatting rules and does not interfere with curly brace placement, indentation conversion, quote style, or any other existing behaviour.

  ## Behaviour

  **With trailing comma** — expanded to multi-line:
  ```dart
  Scaffold(
     appBar: appBar,
     body: body,
     backgroundColor: style.backgroundColor,
  )

  // Without trailing comma — left exactly as written:
  Scaffold(appBar: appBar, body: body)
  // or
  Scaffold(
      appBar: appBar,
      body: body
  )